### PR TITLE
Ef10

### DIFF
--- a/src/EFCore.AuditExtensions.Common/Constants.cs
+++ b/src/EFCore.AuditExtensions.Common/Constants.cs
@@ -10,6 +10,8 @@ internal static class Constants
 
     public static string AuditTriggerPrefix => "Audit_";
 
+    public static string Ef7AuditTriggerPlaceholderName => "AuditTrigger";
+
     public static class AuditTableColumnNames
     {
         public static string OldData = nameof(OldData);

--- a/src/EFCore.AuditExtensions.Common/EFCore.AuditExtensions.Common.csproj
+++ b/src/EFCore.AuditExtensions.Common/EFCore.AuditExtensions.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/EFCore.AuditExtensions.Common/EFCore.AuditExtensions.Common.csproj
+++ b/src/EFCore.AuditExtensions.Common/EFCore.AuditExtensions.Common.csproj
@@ -7,14 +7,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.11" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.11">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
             <PrivateAssets>all</PrivateAssets>
             <!--          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>-->
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.11" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="SmartFormat" Version="3.2.0" />
+        <PackageReference Include="System.Text.Json" Version="7.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/EFCore.AuditExtensions.Common/EFCore.AuditExtensions.Common.csproj
+++ b/src/EFCore.AuditExtensions.Common/EFCore.AuditExtensions.Common.csproj
@@ -7,15 +7,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
             <PrivateAssets>all</PrivateAssets>
             <!--          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>-->
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-        <PackageReference Include="SmartFormat" Version="3.2.0" />
-        <PackageReference Include="System.Text.Json" Version="7.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+        <PackageReference Include="SmartFormat" Version="3.5.1" />
+        <PackageReference Include="System.Text.Json" Version="9.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/EFCore.AuditExtensions.Common/EfCore/EfCoreColumnFactory.cs
+++ b/src/EFCore.AuditExtensions.Common/EfCore/EfCoreColumnFactory.cs
@@ -20,7 +20,7 @@ internal static class EfCoreColumnFactory
             IsNullable = auditTableColumn.Nullable,
         };
         var columnMapping = new ColumnMapping(new Property(auditTableColumn.Name, columnClrType, null, null, entityType, ConfigurationSource.Explicit, null), tableColumn, tableMapping);
-        tableColumn.PropertyMappings.Add(columnMapping);
+        tableColumn.AddPropertyMapping(columnMapping);
 
         return tableColumn;
     }

--- a/src/EFCore.AuditExtensions.Common/EfCore/Models/CustomAuditTableIndex.cs
+++ b/src/EFCore.AuditExtensions.Common/EfCore/Models/CustomAuditTableIndex.cs
@@ -8,6 +8,8 @@ namespace EFCore.AuditExtensions.Common.EfCore.Models;
 
 public class CustomAuditTableIndex : TableIndex
 {
+    public override IReadOnlyList<bool>? IsDescending => MappedIndexes.FirstOrDefault()?.IsDescending;
+
     public override string? Filter => MappedIndexes.FirstOrDefault()?.GetFilter(StoreObjectIdentifier.Table(Table.Name, Table.Schema));
 
     public CustomAuditTableIndex(string name, Table table, IReadOnlyList<Column> columns) : base(name, table, columns, false)

--- a/src/EFCore.AuditExtensions.Common/Migrations/MigrationsModelDiffer.cs
+++ b/src/EFCore.AuditExtensions.Common/Migrations/MigrationsModelDiffer.cs
@@ -25,11 +25,10 @@ public class MigrationsModelDiffer : Microsoft.EntityFrameworkCore.Migrations.In
     public MigrationsModelDiffer(
         IRelationalTypeMappingSource typeMappingSource,
         IMigrationsAnnotationProvider migrationsAnnotations,
-        IChangeDetector changeDetector,
-        IUpdateAdapterFactory updateAdapterFactory,
+        IRowIdentityMapFactory rowIdentityMapFactory,
         CommandBatchPreparerDependencies commandBatchPreparerDependencies,
         ILogger<MigrationsModelDiffer> logger)
-        : base(typeMappingSource, migrationsAnnotations, changeDetector, updateAdapterFactory, commandBatchPreparerDependencies)
+        : base(typeMappingSource, migrationsAnnotations, rowIdentityMapFactory, commandBatchPreparerDependencies)
     {
         _logger = logger;
     }

--- a/src/EFCore.AuditExtensions.Common/Migrations/MigrationsModelDiffer.cs
+++ b/src/EFCore.AuditExtensions.Common/Migrations/MigrationsModelDiffer.cs
@@ -4,13 +4,11 @@ using EFCore.AuditExtensions.Common.EfCore;
 using EFCore.AuditExtensions.Common.Extensions;
 using EFCore.AuditExtensions.Common.Migrations.CSharp.Operations;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Storage;
-using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Update.Internal;
 using Microsoft.Extensions.Logging;
 
@@ -25,10 +23,11 @@ public class MigrationsModelDiffer : Microsoft.EntityFrameworkCore.Migrations.In
     public MigrationsModelDiffer(
         IRelationalTypeMappingSource typeMappingSource,
         IMigrationsAnnotationProvider migrationsAnnotations,
+        IRelationalAnnotationProvider relationalAnnotationProvider,
         IRowIdentityMapFactory rowIdentityMapFactory,
         CommandBatchPreparerDependencies commandBatchPreparerDependencies,
         ILogger<MigrationsModelDiffer> logger)
-        : base(typeMappingSource, migrationsAnnotations, rowIdentityMapFactory, commandBatchPreparerDependencies)
+        : base(typeMappingSource, migrationsAnnotations, relationalAnnotationProvider, rowIdentityMapFactory, commandBatchPreparerDependencies)
     {
         _logger = logger;
     }

--- a/src/EFCore.AuditExtensions.SqlServer/EFCore.AuditExtensions.SqlServer.csproj
+++ b/src/EFCore.AuditExtensions.SqlServer/EFCore.AuditExtensions.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/EFCore.AuditExtensions.SqlServer/EFCore.AuditExtensions.SqlServer.csproj
+++ b/src/EFCore.AuditExtensions.SqlServer/EFCore.AuditExtensions.SqlServer.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.11" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="SmartFormat" Version="3.2.0" />
     </ItemGroup>
 

--- a/src/EFCore.AuditExtensions.SqlServer/EFCore.AuditExtensions.SqlServer.csproj
+++ b/src/EFCore.AuditExtensions.SqlServer/EFCore.AuditExtensions.SqlServer.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-        <PackageReference Include="SmartFormat" Version="3.2.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+        <PackageReference Include="SmartFormat" Version="3.5.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/EFCore.AuditExtensions.SqlServer/SqlGenerators/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.AuditExtensions.SqlServer/SqlGenerators/SqlServerMigrationsSqlGenerator.cs
@@ -3,6 +3,7 @@ using EFCore.AuditExtensions.Common.Migrations.Sql.Operations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Microsoft.EntityFrameworkCore.Update;
 
 namespace EFCore.AuditExtensions.SqlServer.SqlGenerators;
 
@@ -12,7 +13,7 @@ internal class SqlServerMigrationsSqlGenerator : Microsoft.EntityFrameworkCore.M
 
     private readonly IDropAuditTriggerSqlGenerator _dropAuditTriggerSqlGenerator;
 
-    public SqlServerMigrationsSqlGenerator(MigrationsSqlGeneratorDependencies dependencies, IRelationalAnnotationProvider migrationsAnnotations, ICreateAuditTriggerSqlGenerator createAuditTriggerSqlGenerator, IDropAuditTriggerSqlGenerator dropAuditTriggerSqlGenerator) : base(dependencies, migrationsAnnotations)
+    public SqlServerMigrationsSqlGenerator(MigrationsSqlGeneratorDependencies dependencies, ICommandBatchPreparer commandBatchPreparer, ICreateAuditTriggerSqlGenerator createAuditTriggerSqlGenerator, IDropAuditTriggerSqlGenerator dropAuditTriggerSqlGenerator) : base(dependencies, commandBatchPreparer)
     {
         _createAuditTriggerSqlGenerator = createAuditTriggerSqlGenerator;
         _dropAuditTriggerSqlGenerator = dropAuditTriggerSqlGenerator;


### PR DESCRIPTION
Updates for EF10. In the end most of the code changes are to support EF9+, to go to EF10 only required the nugets bumped.

EntityTypeBuilderExtensions is back at its original implementation and working as expected.

I think yesterday I'd got into a confused state with nuget versioning from this into my main app. Apologies for that.